### PR TITLE
Update readme.MD PHP example section

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -239,7 +239,7 @@ $task = new Task();
 $task->setHttpRequest($http);
 $queuePath = $client->queueName('dev', 'here', 'tasks');
 
-$response = $this->client->createTask($queuePath, $task);
+$response = $client->createTask($queuePath, $task);
 ```
 
 ### JavaScript example


### PR DESCRIPTION
There is no need to call `$this->client->createTask($queuePath, $task);` like this. 
Instead, we can call `$client->createTask($queuePath, $task);`